### PR TITLE
[TECHNICAL-SUPPORT] LPS-88600 Guest Role loses View permission of Polls Display portlet after clicking Reset Changes

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PermissionImporterImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PermissionImporterImpl.java
@@ -286,6 +286,31 @@ public class PermissionImporterImpl implements PermissionImporter {
 				mergeImportedPermissionsWithExistingPermissions(
 					existingRoleIdsToActionIds, importedRoleIdsToActionIds);
 
+		List<Long> roleIdsToDelete = new ArrayList<>();
+		List<Long> roleIdsToUpdate = new ArrayList<>(
+			roleIdsToActionIds.keySet());
+
+		for (Long roleId : roleIdsToUpdate) {
+			String[] actionIds = roleIdsToActionIds.get(roleId);
+
+			if ((actionIds.length == 0) &&
+				!importedRoleIdsToActionIds.containsKey(roleId)) {
+
+				roleIdsToActionIds.remove(roleId);
+
+				roleIdsToDelete.add(roleId);
+			}
+		}
+
+		if (!roleIdsToDelete.isEmpty()) {
+			ExportImportPermissionUtil.deleteResourcePermissions(
+				companyId, resourceName, resourcePrimKey, roleIdsToDelete);
+		}
+
+		if (roleIdsToActionIds.isEmpty()) {
+			return;
+		}
+
 		ExportImportPermissionUtil.updateResourcePermissions(
 			companyId, groupId, resourceName, resourcePrimKey,
 			roleIdsToActionIds);

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java
@@ -34,6 +34,24 @@ public class ExportImportPermissionUtil {
 
 	public static final String ROLE_TEAM_PREFIX = "ROLE_TEAM_,*";
 
+	public static void deleteResourcePermissions(
+			long companyId, String resourceName, String resourcePrimKey,
+			List<Long> roleIds)
+		throws PortalException {
+
+		for (long roleId : roleIds) {
+			ResourcePermission resourcePermission =
+				ResourcePermissionLocalServiceUtil.fetchResourcePermission(
+					companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+					resourcePrimKey, roleId);
+
+			if (resourcePermission != null) {
+				ResourcePermissionLocalServiceUtil.deleteResourcePermission(
+					resourcePermission.getResourcePermissionId());
+			}
+		}
+	}
+
 	public static Map<Long, Set<String>> getRoleIdsToActionIds(
 		long companyId, String resourceName, long resourcePK) {
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java
@@ -108,14 +108,16 @@ public class ExportImportPermissionUtil {
 			Map<Long, String[]> importedRoleIdsToActionIds) {
 
 		Map<Long, String[]> mergedRoleIdsToActionIds = new HashMap<>();
+		Map<Long, String[]> newRoleIdsToActionIds = new HashMap<>(
+			importedRoleIdsToActionIds);
 
 		for (Map.Entry<Long, Set<String>> roleIdsToActionIds :
 				existingRoleIdsToActionIds.entrySet()) {
 
 			long roleId = roleIdsToActionIds.getKey();
 
-			if (importedRoleIdsToActionIds.containsKey(roleId)) {
-				String[] actionIds = importedRoleIdsToActionIds.remove(roleId);
+			if (newRoleIdsToActionIds.containsKey(roleId)) {
+				String[] actionIds = newRoleIdsToActionIds.remove(roleId);
 
 				mergedRoleIdsToActionIds.put(roleId, actionIds);
 			}
@@ -124,7 +126,7 @@ public class ExportImportPermissionUtil {
 			}
 		}
 
-		mergedRoleIdsToActionIds.putAll(importedRoleIdsToActionIds);
+		mergedRoleIdsToActionIds.putAll(newRoleIdsToActionIds);
 
 		return mergedRoleIdsToActionIds;
 	}


### PR DESCRIPTION
Hi @ricardocousolr ,

I'm fixing [LPS-88600](https://issues.liferay.com/browse/LPS-88600), since it's a required for backporting [LPS-83659](https://issues.liferay.com/browse/LPS-83659) to 7.0.x.

The issue is quite complex. Let me explain the details:
* Viewing the portlet permissions on the portal has actually a side-effect: even without saving, just opening the permissions window updates the portlet permissions in the DB. It creates ResourcePermission records specific to the portlet.
* When resetting the page changes, a site template propagation is executed: exporting the template, importing it, overwriting the site.
* The portlet in the template has no specific permission records, so an empty `<permissions/>` tag is sent in the LAR file (this is correct).
* The old version of the permission import deleted all permissions ([ExportImportPermissionUtil.java#L128-L130](https://github.com/liferay/liferay-portal/blob/d3f6533ca5d562725651f55b8f7e4ab7f852150d/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java#L128-L130)) and it worked correctly: removing all portlet-specific ResourcePermission records allows it to use the default ones. One problem with this is performance: even when no permissions changed, it deletes and recreates all of them, for every single portlet in the site.
* The new version ([ExportImportPermissionUtil.java](https://github.com/liferay/liferay-portal/blob/c090845cbddd20efc0b42dde04dcf87b2f2a18ab/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java#L129-L140)) did not delete these permissions, but compared them to the imported ones (which was empty). So if the portlet had any specific permission (e.g. someone opened the permissions window once), it updated all of them, role-by-role, with 0 actionIds, effectively removing all permissions specific to the portlet.
* My proposed solution is to combine these two. There's an extra information in the LAR file that we can use: if the template source explicitly removes all permissions from a role, it sends a `<role>` tag, with no `<action>` tags. And when there's no role related records, the `<role>` tag is simply omitted. This part of the code takes this information into account to decide which permission records should be deleted and which one to be updated: https://github.com/ricardocousolr/liferay-portal/commit/b39a235a0d0ff21e43684891b92ea7df59c02059#diff-a88666b67e25acc41f19d430bbc5e9a2R289-R308

cc: @lipusz

Please review my changes.

Thanks,
Vendel