### PR TITLE
[TS] LPS-168169 | After upgrading to 7.4 personalized variations in a collections are not assigned an explicit priority (except Anyone)

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/v1_5_0/AssetListEntrySegmentsEntryRelUpgradeProcess.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/v1_5_0/AssetListEntrySegmentsEntryRelUpgradeProcess.java
@@ -14,9 +14,13 @@
 
 package com.liferay.asset.list.internal.upgrade.v1_5_0;
 
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 /**
  * @author Yurena Cabrera
@@ -26,9 +30,42 @@ public class AssetListEntrySegmentsEntryRelUpgradeProcess
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		runSQL(
-			"update AssetListEntrySegmentsEntryRel set priority = 1 where " +
-				"segmentsEntryId = 0");
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+			"select alEntrySegmentsEntryRelId, assetListEntryId from " +
+			"AssetListEntrySegmentsEntryRel order by assetListEntryId ASC, " +
+			"createDate DESC");
+			 PreparedStatement preparedStatement2 =
+				 AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					 connection,
+					 "update AssetListEntrySegmentsEntryRel set priority = ? " +
+					 "where alEntrySegmentsEntryRelId = ?");
+
+			ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+			long previousAssetListEntryId = -1;
+			long priority = 0;
+
+			while (resultSet.next()) {
+				long alEntrySegmentsEntryRelId = resultSet.getLong(
+					"alEntrySegmentsEntryRelId");
+
+				long assetListEntryId = resultSet.getLong("assetListEntryId");
+
+				if (assetListEntryId != previousAssetListEntryId) {
+					priority = 0;
+				}
+
+				preparedStatement2.setLong(1, priority);
+				preparedStatement2.setLong(2, alEntrySegmentsEntryRelId);
+
+				preparedStatement2.addBatch();
+
+				previousAssetListEntryId = assetListEntryId;
+				priority++;
+			}
+
+			preparedStatement2.executeBatch();
+		}
 	}
 
 	@Override

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -1199,7 +1199,11 @@ public class EditAssetListDisplayContext {
 		return JSONUtil.putAll(
 			stream.sorted(
 				Comparator.comparingInt(
-					AssetListEntrySegmentsEntryRel::getPriority)
+					AssetListEntrySegmentsEntryRel::getPriority
+				).thenComparing(
+						AssetListEntrySegmentsEntryRel::getCreateDate,
+						Comparator.reverseOrder()
+				)
 			).map(
 				assetListEntrySegmentsEntryRel -> JSONUtil.put(
 					"active",


### PR DESCRIPTION
Motivation
=======
[LPS-141797](https://issues.liferay.com/browse/LPS-141797) introduced an upgrade step to set the priority to personalized variations, since this column was introduced as a feature. 

However, this step only set the priorities for the Anyone personalized variation (to `1`) and left the others alone (with a `null` value). 

This underspecification of the priority means that the non-Anyone personalized variations are ordered "randomly" because null values are read as `0` and the code in `EditAssetListDisplayContext#_getAssetListEntrySegmentsEntryRelJSONArray` sorts by `getPriority`. 

Note: When a user reorders the personalized variations the priority values start being set (only those personalized variations that are interacted with, not all). 

See [LPS-168169](https://issues.liferay.com/browse/LPS-168169) for reproducing steps.

Proposed Solution
========
The first part of the solution changes the upgrade step to set a value of priority for all entries. We get all entries in `AssetListEntrySegmentsEntryRel` ordered by `AssetListEntryId` and `createDate` and we go over each setting priorities starting at 0 (more precedence) and resetting to `0` when we `AssetListEntryId` changes. 

The second part of the solution adds a second criterion in `EditAssetListDisplayContext#_getAssetListEntrySegmentsEntryRelJSONArray` to sort also by `createDate` to cover the case when two priorities are the same (or null). This will cover users that have already executed the previous version of the upgrade step (and haven't fiddled with the ordering in the UI).

Note: An alternative approach would be to add a new upgrade step. The code for this step wouldn't be as simple. The reason is that we would need to get all entries in the table sorted by `AssetListEntryId`, then `priority` and then `createDate`. But some values of `priority` could be `null` and the sorting properties of `null` values depend on the particular database manager.


Steps to Verify:
----------------
1. Start a 7.3. Liferay.
2. Create a couple of segments.
3. Create a collection (the type is irrelevant: dynamic or manual).
4. Create a personalized variation for Anyone and the two created segments.
5. Stop the installation.
6. Upgrade to 7.4/master.
7. Check the table `AssetListEntrySegmentsEntryRel` and notice there's a new column Priority.
8. Check that all entries in the table have an assigned value of `priority`, with lowest value (`0`) for the entry with more recent `createDate`. The entry associated with Anyone (`segmentEntryId` equal to `0`) should have the highest value of `priority`.


Checklist (optional):
========
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules [doesn't apply]